### PR TITLE
Add iOS Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,14 @@ jobs:
             target: i686-linux-android
             cmake-options: -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake -DANDROID_ABI=x86 -DANDROID_PLATFORM=android-28
             path: android/x86
+          - os: macOS-latest
+            target: aarch64-apple-ios
+            cmake-options: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_SYSROOT=iphoneos -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0
+            path: ios/arm64
+          - os: macOS-latest
+            target: aarch64-apple-ios-sim
+            cmake-options: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_SYSROOT=iphonesimulator -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0
+            path: ios-simulator/arm64
 
     name: Build
     steps:
@@ -121,4 +129,29 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.target }}
+          path: accesskit-c/lib
+
+  package-ios-xcframework:
+    needs: [build-binaries]
+    runs-on: macOS-latest
+    name: Package iOS xcframework
+
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          pattern: aarch64-apple-ios*
+          path: artifacts
+
+      - name: Create xcframework
+        run: |
+          mkdir -p accesskit-c/lib/ios
+          xcodebuild -create-xcframework \
+            -library artifacts/aarch64-apple-ios/ios/arm64/static/libaccesskit.a \
+            -library artifacts/aarch64-apple-ios-sim/ios-simulator/arm64/static/libaccesskit.a \
+            -output accesskit-c/lib/ios/AccessKit.xcframework
+
+      - name: Upload xcframework
+        uses: actions/upload-artifact@v6
+        with:
+          name: ios-xcframework
           path: accesskit-c/lib

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,6 +94,14 @@ jobs:
             target: i686-linux-android
             cmake-options: -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake -DANDROID_ABI=x86 -DANDROID_PLATFORM=android-28
             path: android/x86
+          - os: macOS-latest
+            target: aarch64-apple-ios
+            cmake-options: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_SYSROOT=iphoneos -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0
+            path: ios/arm64
+          - os: macOS-latest
+            target: aarch64-apple-ios-sim
+            cmake-options: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_SYSROOT=iphonesimulator -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0
+            path: ios-simulator/arm64
 
     name: Build
     steps:
@@ -122,8 +130,33 @@ jobs:
           name: ${{ matrix.target }}
           path: accesskit-c/lib
 
-  publish:
+  package-ios-xcframework:
     needs: [build-binaries]
+    runs-on: macOS-latest
+    name: Package iOS xcframework
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: aarch64-apple-ios*
+          path: artifacts
+
+      - name: Create xcframework
+        run: |
+          mkdir -p accesskit-c/lib/ios
+          xcodebuild -create-xcframework \
+            -library artifacts/aarch64-apple-ios/ios/arm64/static/libaccesskit.a \
+            -library artifacts/aarch64-apple-ios-sim/ios-simulator/arm64/static/libaccesskit.a \
+            -output accesskit-c/lib/ios/AccessKit.xcframework
+
+      - name: Upload xcframework
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-xcframework
+          path: accesskit-c/lib
+
+  publish:
+    needs: [build-binaries, package-ios-xcframework]
     runs-on: ubuntu-latest
     name: Publish
 


### PR DESCRIPTION
> [!NOTE]
> AI-assisted: drafted with Claude Code and human-reviewed/tested.

## Summary

Adds iOS device and simulator targets to the build matrix, bundled as a single `AccessKit.xcframework`. This unblocks the in-progress Godot iOS AccessKit integration https://github.com/godotengine/godot/pull/119698 which needs prebuilt iOS slices to link against.

## Changes

- **Submodule bump:** `accesskit-c` → 0.22.1 (first release with iOS adapters from [AccessKit/accesskit-c#94](https://github.com/AccessKit/accesskit-c/pull/94) and a usable prebuilt-binaries archive; 0.22.0 was skipped due to a release-pipeline issue).
- **Matrix entries** (added to both `ci.yml` and `publish.yml`):
  - `aarch64-apple-ios` → `lib/ios/arm64/static/libaccesskit.a`
  - `aarch64-apple-ios-sim` → `lib/ios-simulator/arm64/static/libaccesskit.a`
- **New job `package-ios-xcframework`** (in both workflows): downloads the two iOS artifacts and runs `xcodebuild -create-xcframework` to produce `lib/ios/AccessKit.xcframework`. The `publish` job now depends on this so the xcframework lands in the release zip.

## Why xcframework?

iOS device and simulator slices have the same CPU (arm64) but different platform variants and **cannot be `lipo`-merged**. An xcframework is Apple's official container that lets Xcode select the correct slice at link time based on the active SDK. The device-only slice ends up in App Store builds; no simulator code is shipped.

## Local verification

- `cmake -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos ...` + build + install produces a valid arm64 `libaccesskit.a` at the expected `lib/ios/arm64/static/` path.
- Same for `iphonesimulator` at `lib/ios-simulator/arm64/static/`.
- `xcodebuild -create-xcframework` produces `AccessKit.xcframework` with `ios-arm64` and `ios-arm64-simulator` slices and a correct `Info.plist` (`SupportedPlatformVariant=simulator` on the second slice).
